### PR TITLE
shorter links from Journal

### DIFF
--- a/zim/gui/clipboard.py
+++ b/zim/gui/clipboard.py
@@ -13,6 +13,7 @@ import gtk
 import logging
 
 from zim.fs import File, Dir, FS
+from zim.main import ZIM_APPLICATION
 from zim.newfs import LocalFolder
 from zim.notebook import Path
 from zim.parsing import is_url_re, url_encode, link_type, URL_ENCODE_READABLE
@@ -279,12 +280,16 @@ def _link_tree(links, notebook, path):
 			if type == 'page':
 				target = Path(Path.makeValidPageName(link)) # Assume links are always absolute
 				href = notebook.pages.create_link(path, target)
-				link = href.to_wiki_link()
+				name = link = href.to_wiki_link()
+                                for window in ZIM_APPLICATION._windows: # Allow shorter links from Journal
+                                    if window.ui.plugins and window.ui.plugins['calendar'].preferences["link_shortname"] is True and name.startswith("Journal"):
+                                        pos = name.rfind(":")
+                                        name = name[pos+1:]
+                                    break
 			elif type == 'file':
 				file = File(link) # Assume links are always URIs
-				link = notebook.relative_filepath(file, path) or file.uri
-
-			builder.append(LINK, {'href': link}, link)
+				name = link = notebook.relative_filepath(file, path) or file.uri
+			builder.append(LINK, {'href': link}, name)
 
 	builder.end(FORMATTEDTEXT)
 	tree = builder.get_parsetree()

--- a/zim/plugins/calendar.py
+++ b/zim/plugins/calendar.py
@@ -109,6 +109,7 @@ Also adds a calendar widget to access these pages.
 		('granularity', 'choice', _('Use a page for each'), DAY, (DAY, WEEK, MONTH, YEAR)), # T: preferences option, values will be "Day", "Month", ...
 		('namespace', 'namespace', _('Section'), Path(':Journal')), # T: input label
 		('auto_expand_in_index', 'bool', _('Expand journal page in index when opened'), True), # T: preferences option
+		('link_shortname', 'bool', _('When copying a link to a file, use shorter name (IE my-page instead of Journal:2017:06:my-page)'), False), # T: preferences option
 	)
 	# TODO disable pane setting if not embedded
 


### PR DESCRIPTION
I'd like to have shorter links from Journal. So I've added new plugin option.

![image](https://user-images.githubusercontent.com/6942231/26937972-29393e52-4c73-11e7-8b98-47bade50a6d1.png)

If this option is set to True, when copying a link from Journal, only the short form gets pasted. 

![image](https://user-images.githubusercontent.com/6942231/26938023-4e2bf45c-4c73-11e7-95af-300a106ef21c.png)

For this case, only "diplomka" is pasted instead of "Journal:2015:05:diplomka" when copying location.

![image](https://user-images.githubusercontent.com/6942231/26938150-affb3c10-4c73-11e7-85cc-85362b5980e5.png)

Please advise me, how to read the plugin preferences correctly? Now, I'm just examining ui from ZIM_APPLICATION.
