### PR TITLE
Add navigation.home for export templates

### DIFF
--- a/data/manual/Help/Templates.txt
+++ b/data/manual/Help/Templates.txt
@@ -235,7 +235,7 @@ title			Page title
 
 navigation		links to other export pages (if not included in the same output file)
 	.home
-	.up
+	.up					(not implemented yet)
 	.prev
 	.next
 

--- a/zim/export/exporters/files.py
+++ b/zim/export/exporters/files.py
@@ -138,7 +138,8 @@ class MultiFileExporter(FilesExporterBase):
 			linker_factory, dumper_factory,
 			title=page.get_title(),
 			content=[page],
-			home=None, up=None, # TODO
+			home=notebook.get_home_page(),
+			up=None, # TODO
 			prevpage=prevpage, nextpage=nextpage,
 			links={'index': self.index_page},
 			index_generator=pages.index,


### PR DESCRIPTION
Make navigation.home available for export templates.
Also, add a remark to the Templates help page that navigation.up is not yet implemented.