### PR TITLE
Use buffer_initialize for gtkspellcheck>=4.0.3 - fixes #168

### DIFF
--- a/tests/spell.py
+++ b/tests/spell.py
@@ -48,13 +48,14 @@ class TestSpell(object):
 			ext.toggle_spellcheck()
 			ext.toggle_spellcheck()
 
-			ui.open_page(Path('Foo'))
-			ui.open_page(Path('Bar'))
-			ext.toggle_spellcheck()
-
-			ui.open_page(Path('Foo'))
-			ui.open_page(Path('Bar'))
-			ext.toggle_spellcheck()
+			import resource
+			start_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+			for i in range(4):
+				ui.open_page(Path('Foo'))
+				ui.open_page(Path('Bar'))
+				ext.toggle_spellcheck()
+			end_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+			self.assertTrue(end_rss - start_rss < 10240, 'switching pages leaks RAM')
 
 			# TODO check it actually shows on screen ...
 


### PR DESCRIPTION
Also test for spell checker is expanded to check for memory leak.

For fixed plugin memory usage difference after stress test is about
600-800 KiB. On the other hand unfixed plugin leaks 90 MB or 210
depending on system on which I run test. Therefore 10 MiB is chosen as
safe intermediate threshold to catch leaks but stay silent without leak.