### PR TITLE
versioncontrol improvements for git staging

### DIFF
--- a/zim/plugins/versioncontrol/__init__.py
+++ b/zim/plugins/versioncontrol/__init__.py
@@ -105,11 +105,6 @@ class NotebookExtension(ObjectExtension):
 	def detect_vcs(self):
 		dir = self._get_notebook_dir()
 		self.vcs = VCS.detect_in_folder(dir)
-		if self.vcs and self.vcs.use_staging:
-			# HACK - FIXME use proper FS signals here
-			# git requires changes to be added to staging, bzr does not
-			# so add a hook for when page is written, to update staging.
-			self.connectto(self.notebook, 'stored-page', self.vcs.update_staging)
 
 	def init_vcs(self, vcs):
 		dir = self._get_notebook_dir()
@@ -418,10 +413,6 @@ class VCSBackend(ConnectorMixin):
 			))
 
 	@property
-	def use_staging(self):
-		return self._app.use_staging
-
-	@property
 	def vcs(self):
 		return self._app
 
@@ -578,14 +569,9 @@ class VCSBackend(ConnectorMixin):
 			version = self.vcs.cat(file, version)
 		return version
 
-	def update_staging(self, notebook, page):
-		file, x = notebook.layout.map_page(page)
-		file = File(file.path) # newfs.LocalFile --> File
-		self.stage(file)
-
-	def stage(self, file):
+	def stage(self):
 		with self.lock:
-			self.vcs.stage(file)
+			self.vcs.stage()
 
 
 class VCSApplicationBase(object):
@@ -852,10 +838,7 @@ class VCSApplicationBase(object):
 		raise NotImplementedError
 
 	def stage(self):
-		"""Fixme - to be documented
-		Usefull for git, runs:
-		  git add -u
-		  git add -A
+		"""Prepares the repo for a commit. Used, for example, by git to stage changes so that the status message in SaveVersionDialog shows what will be committed.
 
 		@implementation: optional to be implemented in child class
 		"""
@@ -939,6 +922,7 @@ class SaveVersionDialog(Dialog):
 		label.set_alignment(0, 0.5)
 		vbox.pack_start(label, False)
 
+		self.vcs.stage()
 		status = self.vcs.get_status()
 		window, textview = ScrolledTextView(text=''.join(status), monospace=True)
 		vbox.add(window)

--- a/zim/plugins/versioncontrol/bzr.py
+++ b/zim/plugins/versioncontrol/bzr.py
@@ -17,8 +17,6 @@ logger = logging.getLogger('zim.vcs.bzr')
 
 class BZRApplicationBackend(VCSApplicationBase):
 
-	use_staging = False
-
 	@classmethod
 	def build_bin_application_instance(cls):
 		return Application(('bzr',))

--- a/zim/plugins/versioncontrol/fossil.py
+++ b/zim/plugins/versioncontrol/fossil.py
@@ -23,8 +23,6 @@ RE_Time = re.compile(r"[0-9][0-9]:[0-9][0-9]:[0-9][0-9]")
 
 class FOSSILApplicationBackend(VCSApplicationBase):
 
-	use_staging = False
-
 	@classmethod
 	def build_bin_application_instance(cls):
 		return Application(('fossil',))

--- a/zim/plugins/versioncontrol/git.py
+++ b/zim/plugins/versioncontrol/git.py
@@ -16,27 +16,7 @@ from zim.applications import Application
 logger = logging.getLogger('zim.vcs.git')
 
 
-# NOTE about staging: git has the concept of an "index" or "staging area"
-# that captures changes for the next commit and which is seperate from the
-# changes in the working directory. Specifically in contrast to the other
-# vcs systems supported in zim, git "add" only adds changes at that time, not
-# the files itself.
-#
-# Two operation modes:
-# 1. commit done through zim, we can run "add" on commit time and capture all
-#    changes, but also e.g. attachments added via the file manager
-# 2. commit is done outside of zim, we can run "add" on page and file changes
-#    to ensure latest version is captured by git commit. We do not cover files
-#    added e.g. via file manager in this case
-#
-# Thus we need to update staging on each page and file change, as well as
-# look for new files on commit.
-#
-
-
 class GITApplicationBackend(VCSApplicationBase):
-
-	use_staging = True
 
 	@classmethod
 	def build_bin_application_instance(cls):
@@ -111,10 +91,10 @@ class GITApplicationBackend(VCSApplicationBase):
 
 	def commit(self, path, msg):
 		"""
-		Runs: git commit -a -m {{MSG}} {{PATH}}
+		Runs: git commit -m {{MSG}} {{PATH}}
 		"""
 		if self.is_modified():
-			params = ['commit', '-a']
+			params = ['commit']
 			if msg != '' and msg is not None:
 				params.append('-m')
 				params.append(msg)
@@ -247,8 +227,8 @@ class GITApplicationBackend(VCSApplicationBase):
 		else:
 			self.run(['reset', '--hard', 'HEAD'])
 
-	def stage(self, file):
-		self.run(['add', file.relpath(self.root)])
+	def stage(self):
+		self.add()
 
 	def status(self, porcelain=False):
 		"""

--- a/zim/plugins/versioncontrol/hg.py
+++ b/zim/plugins/versioncontrol/hg.py
@@ -21,8 +21,6 @@ logger = logging.getLogger('zim.vcs.hg')
 
 class HGApplicationBackend(VCSApplicationBase):
 
-	use_staging = False
-
 	@classmethod
 	def build_bin_application_instance(cls):
 		return Application(('hg', '--noninteractive', '--encoding', 'utf8'), encoding='utf-8')


### PR DESCRIPTION
Change stage() to mean "prepare the repo for a commit". It is called by SaveVersionDialog before getting the status of the repo. It is only implemented for git, where it does a 'git add' on the whole notebook, so that the status message accurately reflects what will be committed.

Remove '-a' from 'git commit'. Both stage() and VCSBackend.commit() call add() before commit(). Having '-a' here might capture unwanted changes in a zim commit, if the notebook is part of larger repo.

Remove use_staging. It was only used with git and the new way of staging means it isn't necessary.

Fixes #249