### PR TITLE
When removing a symlinked directory, make sure it's empty.

### DIFF
--- a/zim/newfs/local.py
+++ b/zim/newfs/local.py
@@ -34,7 +34,7 @@ def _os_lrmdir(path):
 	try:
 		os.rmdir(path)
 	except OSError:
-		if os.path.islink(path) and os.path.isdir(path):
+		if os.path.islink(path) and os.path.isdir(path) and not os.listdir(path):
 			os.unlink(path)
 		else:
 			raise


### PR DESCRIPTION
Fixes #238