### PR TITLE
Change metainfo ID to 'org.zim_wiki.Zim'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ def collect_data_files():
 		('share/applications', ['xdg/zim.desktop']),
 		('share/mime/packages', ['xdg/zim.xml']),
 		('share/pixmaps', ['xdg/hicolor/48x48/apps/zim.png']),
-		('share/metainfo', ['xdg/org.zim-wiki.Zim.metainfo.xml']),
+		('share/metainfo', ['xdg/org.zim_wiki.Zim.metainfo.xml']),
 	]
 
 	# xdg/hicolor -> PREFIX/share/icons/hicolor

--- a/xdg/org.zim_wiki.Zim.metainfo.xml
+++ b/xdg/org.zim_wiki.Zim.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Ryan Lerch <rlerch@redhat.com>, 2018 Jaap Karssenberg <jaap.karssenberg@gmail.com> -->
 <component type="desktop">
-  <id>org.zim-wiki.Zim</id>
+  <id>org.zim_wiki.Zim</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
 	<name>Zim</name>


### PR DESCRIPTION
Hyphens are discouraged to be used with respect to recent version of AppStream,
and 'org.zim-wiki.Zim' failed to be a valid Flatpak ID.