### PR TITLE
MainWindow: Remove unnecessary layer of HBox

### DIFF
--- a/zim/gui/mainwindow.py
+++ b/zim/gui/mainwindow.py
@@ -182,12 +182,9 @@ class MainWindow(Window):
 		self.add(self.pageview)
 
 		# create statusbar
-		hbox = Gtk.HBox(spacing=0)
-		self.add_bar(hbox, BOTTOM)
-
 		self.statusbar = Gtk.Statusbar()
 		self.statusbar.push(0, '<page>')
-		hbox.add(self.statusbar)
+		self.add_bar(self.statusbar, BOTTOM)
 
 		def statusbar_element(string, size):
 			frame = Gtk.Frame()
@@ -212,12 +209,6 @@ class MainWindow(Window):
 		frame.add(self.statusbar_backlinks_button)
 
 		self.move_bottom_minimized_tabs_to_statusbar(self.statusbar)
-
-		# add a second statusbar widget - somehow the corner grip
-		# does not render properly after the pack_end for the first one
-		#~ statusbar2 = Gtk.Statusbar()
-		#~ statusbar2.set_size_request(25, 10)
-		#~ hbox.pack_end(statusbar2, False, True, 0)
 
 		self.do_preferences_changed()
 

--- a/zim/gui/mainwindow.py
+++ b/zim/gui/mainwindow.py
@@ -185,6 +185,7 @@ class MainWindow(Window):
 		self.statusbar = Gtk.Statusbar()
 		self.statusbar.push(0, '<page>')
 		self.add_bar(self.statusbar, BOTTOM)
+		self.statusbar.set_property('margin', 0)
 
 		def statusbar_element(string, size):
 			frame = Gtk.Frame()

--- a/zim/gui/widgets.py
+++ b/zim/gui/widgets.py
@@ -3207,6 +3207,7 @@ class ErrorDialog(Gtk.MessageDialog):
 			buttons=buttons,
 			text=msg
 		)
+		self.set_resizable(True)
 		self.set_transient_for(get_window(parent))
 		self.set_modal(True)
 
@@ -3226,6 +3227,7 @@ class ErrorDialog(Gtk.MessageDialog):
 			text = self.get_debug_text(exc_info)
 			window, textview = ScrolledTextView(text, monospace=True)
 			window.set_size_request(350, 200)
+			window.set_property('expand', True)
 			self.vbox.add(window)
 			self.vbox.show_all()
 			# TODO use an expander here ?


### PR DESCRIPTION
Also remove comment about resize grip which has been removed from Gtk.Statusbar.
Resize grips have resided in Gtk.Window but have been removed there too in the
mean time.