### PR TITLE
Reduce status bar height; unbreak mnemonics in context menu

### DIFF
--- a/zim/gui/pageview.py
+++ b/zim/gui/pageview.py
@@ -5703,14 +5703,14 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 				item.set_sensitive(False)
 			copy_as_menu.append(item)
 
-		item = Gtk.MenuItem(_('Copy _As...')) # T: menu item for context menu of editor
+		item = Gtk.MenuItem.new_with_mnemonic(_('Copy _As...')) # T: menu item for context menu of editor
 		item.set_submenu(copy_as_menu)
 		item.show_all()
 		menu.insert(item, 2) # position after Copy in the standard menu - may not be robust...
 			# FIXME get code from test to seek stock item
 
 		### Move text to new page ###
-		item = Gtk.MenuItem(_('Move Selected Text...'))
+		item = Gtk.MenuItem.new_with_mnemonic(_('Move Selected Text...'))
 			# T: Context menu item for pageview to move selected text to new/other page
 		item.show_all() # FIXME should not be needed here
 		menu.insert(item, 7) # position after Copy in the standard menu - may not be robust...
@@ -5761,16 +5761,16 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 
 		# remove link
 		if link:
-			item = Gtk.MenuItem(_('_Remove Link'))
+			item = Gtk.MenuItem.new_with_mnemonic(_('_Remove Link'))
 			item.connect('activate', lambda o: self.remove_link(iter=iter))
 			item.set_sensitive(not self.readonly)
 			menu.prepend(item)
 
 		# edit
 		if type == 'image':
-			item = Gtk.MenuItem(_('_Edit Properties')) # T: menu item in context menu for image
+			item = Gtk.MenuItem.new_with_mnemonic(_('_Edit Properties')) # T: menu item in context menu for image
 		else:
-			item = Gtk.MenuItem(_('_Edit Link')) # T: menu item in context menu
+			item = Gtk.MenuItem.new_with_mnemonic(_('_Edit Link')) # T: menu item in context menu
 		item.connect('activate', lambda o: self.edit_object(iter=iter))
 		item.set_sensitive(not self.readonly)
 		menu.prepend(item)
@@ -5790,20 +5790,20 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 			SelectionClipboard.set_uri(uri)
 
 		if type == 'page':
-			item = Gtk.MenuItem(_('Copy _Link')) # T: context menu item
+			item = Gtk.MenuItem.new_with_mnemonic(_('Copy _Link')) # T: context menu item
 			path = self.notebook.pages.resolve_link(
 				self.page, HRef.new_from_wiki_link(link['href'])
 			)
 			item.connect('activate', set_pagelink, path)
 		elif type == 'interwiki':
-			item = Gtk.MenuItem(_('Copy _Link')) # T: context menu item
+			item = Gtk.MenuItem.new_with_mnemonic(_('Copy _Link')) # T: context menu item
 			url = interwiki_link(link['href'])
 			item.connect('activate', set_interwikilink, (link['href'], url))
 		elif type == 'mailto':
-			item = Gtk.MenuItem(_('Copy Email Address')) # T: context menu item
+			item = Gtk.MenuItem.new_with_mnemonic(_('Copy Email Address')) # T: context menu item
 			item.connect('activate', set_uri, file or link['href'])
 		else:
-			item = Gtk.MenuItem(_('Copy _Link')) # T: context menu item
+			item = Gtk.MenuItem.new_with_mnemonic(_('Copy _Link')) # T: context menu item
 			item.connect('activate', set_uri, file or link['href'])
 		menu.prepend(item)
 
@@ -5811,7 +5811,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 
 		# open with & open folder
 		if type in ('file', 'image') and file:
-			item = Gtk.MenuItem(_('Open Folder'))
+			item = Gtk.MenuItem.new_with_mnemonic(_('Open Folder'))
 				# T: menu item to open containing folder of files
 			menu.prepend(item)
 			dir = file.dir
@@ -5820,7 +5820,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 			else:
 				item.set_sensitive(False)
 
-			item = Gtk.MenuItem(_('Open With...'))
+			item = Gtk.MenuItem.new_with_mnemonic(_('Open With...'))
 				# T: menu item for sub menu with applications
 			menu.prepend(item)
 			if file.exists():
@@ -5831,7 +5831,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 		elif type not in ('page', 'notebook', 'interwiki', 'file', 'image'): # urls etc.
 			# FIXME: for interwiki inspect final link and base
 			# open with menu beased on that url type
-			item = Gtk.MenuItem(_('Open With...'))
+			item = Gtk.MenuItem.new_with_mnemonic(_('Open With...'))
 			menu.prepend(item)
 			submenu = OpenWithMenu(self, link['href'])
 			if submenu.get_children():
@@ -5841,7 +5841,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 
 		# open in new window
 		if type == 'page':
-			item = Gtk.MenuItem(_('Open in New _Window'))
+			item = Gtk.MenuItem.new_with_mnemonic(_('Open in New _Window'))
 				# T: menu item to open a link
 			item.connect(
 				'activate', lambda o: self.activate_link(link, new_window=True))
@@ -5851,7 +5851,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 		if type == 'image':
 			link = {'href': file.uri}
 
-		item = Gtk.MenuItem(_('_Open'))
+		item = Gtk.MenuItem.new_with_mnemonic(_('_Open'))
 			# T: menu item to open a link or file
 		if file and not file.exists():
 			item.set_sensitive(False)

--- a/zim/gui/widgets.py
+++ b/zim/gui/widgets.py
@@ -609,9 +609,9 @@ class SingleClickTreeView(Gtk.TreeView):
 		@param menu: the C{Gtk.Menu} object for the popup
 		@param prepend: if C{False} append, if C{True} prepend
 		'''
-		expand = Gtk.MenuItem(_("Expand _All")) # T: menu item in context menu
+		expand = Gtk.MenuItem.new_with_mnemonic(_("Expand _All")) # T: menu item in context menu
 		expand.connect_object('activate', self.__class__.expand_all, self)
-		collapse = Gtk.MenuItem(_("_Collapse All")) # T: menu item in context menu
+		collapse = Gtk.MenuItem.new_with_mnemonic(_("_Collapse All")) # T: menu item in context menu
 		collapse.connect_object('activate', self.__class__.collapse_all, self)
 
 		populate_popup_add_separator(menu, prepend=prepend)

--- a/zim/gui/widgets.py
+++ b/zim/gui/widgets.py
@@ -733,6 +733,10 @@ class MenuButton(Gtk.HBox):
 		if status_bar_style:
 			button_set_statusbar_style(self.button)
 			widget = self.label
+			statusbar_backlink_style = self.button.get_style_context()
+			statusbar_css_provider = Gtk.CssProvider()
+			statusbar_backlink_style.add_provider(statusbar_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+			statusbar_css_provider.load_from_data(b"#zim-statusbar-button {padding: 0px;}")
 		else:
 			arrow = Gtk.Arrow(Gtk.ArrowType.UP, Gtk.ShadowType.NONE)
 			widget = Gtk.HBox(spacing=3)

--- a/zim/plugins/attachmentbrowser/filebrowser.py
+++ b/zim/plugins/attachmentbrowser/filebrowser.py
@@ -331,7 +331,7 @@ class FileBrowserIconView(Gtk.IconView):
 		iter = store.get_iter(pathinfo)
 		file = self.folder.file(store[iter][BASENAME_COL])
 
-		item = Gtk.MenuItem(_('Open With...')) # T: menu item
+		item = Gtk.MenuItem.new_with_mnemonic(_('Open With...')) # T: menu item
 		menu.prepend(item)
 
 		window = self.get_toplevel()
@@ -411,16 +411,16 @@ class FileBrowserIconView(Gtk.IconView):
 		elif action == Gdk.DragAction.ASK:
 			menu = Gtk.Menu()
 
-			item = Gtk.MenuItem(_('_Move Here')) # T: popup menu action on drag-drop of a file
+			item = Gtk.MenuItem.new_with_mnemonic(_('_Move Here')) # T: popup menu action on drag-drop of a file
 			item.connect('activate', lambda o: self._move_files(files))
 			menu.append(item)
 
-			item = Gtk.MenuItem(_('_Copy Here')) # T: popup menu action on drag-drop of a file
+			item = Gtk.MenuItem.new_with_mnemonic(_('_Copy Here')) # T: popup menu action on drag-drop of a file
 			item.connect('activate', lambda o: self._copy_files(files))
 			menu.append(item)
 
 			menu.append(Gtk.SeparatorMenuItem())
-			item = Gtk.MenuItem(_('Cancel')) # T: popup menu action on drag-drop of a file
+			item = Gtk.MenuItem.new_with_mnemonic(_('Cancel')) # T: popup menu action on drag-drop of a file
 			# cancel action needs no action
 			menu.append(item)
 

--- a/zim/plugins/backlinkpane.py
+++ b/zim/plugins/backlinkpane.py
@@ -121,7 +121,7 @@ class BackLinksWidget(Gtk.ScrolledWindow, WindowSidePaneWidget):
 	def on_populate_popup(self, treeview, menu):
 		populate_popup_add_separator(menu)
 
-		item = Gtk.MenuItem(_('Open in New _Window'))
+		item = Gtk.MenuItem.new_with_mnemonic(_('Open in New _Window'))
 		item.connect('activate', self.on_open_new_window, treeview)
 		menu.append(item)
 

--- a/zim/plugins/bookmarksbar.py
+++ b/zim/plugins/bookmarksbar.py
@@ -135,7 +135,7 @@ class BookmarksBarMainWindowExtension(WindowExtension):
 		if path:
 			item = Gtk.SeparatorMenuItem()
 			menu.prepend(item)
-			item = Gtk.MenuItem(_('Add Bookmark')) # T: menu item bookmark plugin
+			item = Gtk.MenuItem.new_with_mnemonic(_('Add Bookmark')) # T: menu item bookmark plugin
 			page = self.window.notebook.get_page(path)
 			item.connect('activate', lambda o: self.widget.add_new_page(page))
 			menu.prepend(item)
@@ -331,7 +331,7 @@ class BookmarkBar(Gtk.HBox, ConnectorMixin):
 		if ask_confirmation:
 			# Prevent accidental deleting of all bookmarks.
 			menu = Gtk.Menu()
-			item = Gtk.MenuItem(_('Do you want to delete all bookmarks?')) # T: message for bookmark plugin
+			item = Gtk.MenuItem.new_with_mnemonic(_('Do you want to delete all bookmarks?')) # T: message for bookmark plugin
 			item.connect('activate', lambda o: _delete_all())
 			menu.append(item)
 			menu.show_all()

--- a/zim/plugins/sourceview.py
+++ b/zim/plugins/sourceview.py
@@ -368,7 +368,7 @@ class SourceViewWidget(TextViewWidget):
 		def activate_lang(item):
 			self.obj.set_language(item.zim_sourceview_languageid)
 
-		item = Gtk.MenuItem(_('Syntax'))
+		item = Gtk.MenuItem.new_with_mnemonic(_('Syntax'))
 		item.set_sensitive(self.view.get_editable())
 		submenu = Gtk.Menu()
 		for lang in sorted(LANGUAGES, key=lambda k: k.lower()):

--- a/zim/plugins/trayicon.py
+++ b/zim/plugins/trayicon.py
@@ -128,7 +128,7 @@ class TrayIconBase(object):
 		'''Returns the main 'tray icon menu'''
 		menu = Gtk.Menu()
 
-		item = Gtk.MenuItem(_('_Quick Note...')) # T: menu item in tray icon menu
+		item = Gtk.MenuItem.new_with_mnemonic(_('_Quick Note...')) # T: menu item in tray icon menu
 		item.connect_object('activate', self.__class__.do_quick_note, self)
 		menu.append(item)
 
@@ -137,14 +137,14 @@ class TrayIconBase(object):
 		notebooks = self.list_all_notebooks()
 		self.populate_menu_with_notebooks(menu, notebooks)
 
-		item = Gtk.MenuItem('  ' + _('_Other...'))  # Hack - using '  ' to indent visually
+		item = Gtk.MenuItem.new_with_mnemonic('  ' + _('_Other...'))  # Hack - using '  ' to indent visually
 			# T: menu item in tray icon menu
 		item.connect_object('activate', self.__class__.do_open_notebook, self)
 		menu.append(item)
 
 		menu.append(Gtk.SeparatorMenuItem())
 
-		item = Gtk.MenuItem(_('_Quit')) # T: menu item in tray icon menu
+		item = Gtk.MenuItem.new_with_mnemonic(_('_Quit')) # T: menu item in tray icon menu
 		item.connect_object('activate', self.__class__.do_quit, self)
 		menu.append(item)
 
@@ -193,7 +193,7 @@ class TrayIconBase(object):
 	def populate_menu_with_notebooks(self, menu, notebooks):
 		'''Populate a menu with a list of notebooks'''
 		# TODO put checkbox behind open notebooks ?
-		item = Gtk.MenuItem(_('Notebooks')) # T: menu item in tray icon menu
+		item = Gtk.MenuItem.new_with_mnemonic(_('Notebooks')) # T: menu item in tray icon menu
 		item.set_sensitive(False)
 		menu.append(item)
 


### PR DESCRIPTION
By making the largest widget in Zim's status bar smaller, it gets as tiny as
with Gtk+ 2.x.

Fixes #342.