### PR TITLE
fix #295 indent in dump_list

### DIFF
--- a/zim/formats/plain.py
+++ b/zim/formats/plain.py
@@ -124,11 +124,11 @@ class Dumper(DumperClass):
 		if 'indent' in attrib:
 			# top level list with specified indent
 			prefix = '\t' * int(attrib['indent'])
-			return self.prefix_lines('\t', strings)
+			return self.prefix_lines(prefix, strings)
 		elif self.context[-1].tag in (BULLETLIST, NUMBEREDLIST):
 			# indent sub list
 			prefix = '\t'
-			return self.prefix_lines('\t', strings)
+			return self.prefix_lines(prefix, strings)
 		else:
 			# top level list, no indent
 			return strings


### PR DESCRIPTION
`zim/formats/plain.py` it looks like it was started and unfinished

fix https://github.com/jaap-karssenberg/zim-desktop-wiki/issues/295