### PR TITLE
Gtk3: Some fixes for clipboard (copy, paste) and DnD (drag and drop)

### DIFF
--- a/zim/gui/clipboard.py
+++ b/zim/gui/clipboard.py
@@ -119,12 +119,12 @@ def pack_urilist(links):
 		if is_url_re.match(link):
 			link = url_encode(link, mode=URL_ENCODE_READABLE) # just to be sure
 		text += '%s\r\n' % link
-	return text
+	return text.encode()
 
 
 def unpack_urilist(text):
 	# FIXME be tolerant here for file://path/to/file uris here
-	text = text.strip('\x00') # Found trailing NULL character on windows
+	text = text.strip(b'\x00').decode() # Found trailing NULL character on windows
 	lines = text.splitlines() # takes care of \r\n
 	return [line for line in lines if line and not line.isspace()]
 		# Just to be sure we also skip empty or whitespace lines

--- a/zim/gui/clipboard.py
+++ b/zim/gui/clipboard.py
@@ -388,7 +388,8 @@ class InterWikiLinkItem(UriItem):
 		self.interwiki_href = href
 
 	def _get(self, clipboard, selectiondata, id, *a):
-		logger.debug("Clipboard requests data as '%s', we have an interwiki link", selectiondata.target)
+		logger.debug("Clipboard requests data as '%s', we have an interwiki link",
+					selectiondata.get_target().name())
 		if id == PARSETREE_TARGET_ID:
 			tree = _link_tree((self.interwiki_href,), None, None)
 			xml = tree.tostring()
@@ -419,7 +420,8 @@ class ParseTreeItem(ClipboardItem):
 		@param id: target id for the requested data format
 		@param a: any additional arguments are discarded
 		'''
-		logger.debug("Clipboard requests data as '%s', we have a parsetree", selectiondata.target)
+		logger.debug("Clipboard requests data as '%s', we have a parsetree",
+					selectiondata.get_target().name())
 		if id == PARSETREE_TARGET_ID:
 			# TODO make links absolute (?)
 			xml = self.parsetree.tostring()
@@ -428,9 +430,9 @@ class ParseTreeItem(ClipboardItem):
 			dumper = get_format('html').Dumper(
 				linker=StaticExportLinker(self.notebook, source=self.path))
 			html = ''.join(dumper.dump(self.parsetree))
-			html = wrap_html(html, target=selectiondata.target)
+			html = wrap_html(html, target=selectiondata.get_target().name())
 			#~ print('PASTING: >>>%s<<<' % html)
-			selectiondata.set(selectiondata.target, 8, html)
+			selectiondata.set(selectiondata.get_target(), 8, html)
 		elif id == TEXT_TARGET_ID:
 			logger.debug("Clipboard requested text, we provide '%s'" % self.format)
 			#~ print(">>>>", self.format, parsetree.tostring())
@@ -467,7 +469,8 @@ class PageLinkItem(ClipboardItem):
 		@param id: target id for the requested data format
 		@param a: any additional arguments are discarded
 		'''
-		logger.debug("Clipboard requests data as '%s', we have a pagelink", selectiondata.target)
+		logger.debug("Clipboard requests data as '%s', we have a pagelink",
+					selectiondata.get_target().name())
 		if id == INTERNAL_PAGELIST_TARGET_ID:
 			text = pack_urilist((self.path.name,))
 			selectiondata.set(INTERNAL_PAGELIST_TARGET_NAME, 8, text)

--- a/zim/plugins/attachmentbrowser/filebrowser.py
+++ b/zim/plugins/attachmentbrowser/filebrowser.py
@@ -390,20 +390,20 @@ class FileBrowserIconView(Gtk.IconView):
 
 	# TODO - test drag and drop
 	def on_drag_data_get(self, iconview, dragcontext, selectiondata, info, time):
-		assert selectiondata.target in URI_TARGET_NAMES
+		assert selectiondata.get_target().name() in URI_TARGET_NAMES
 		paths = self.get_selected_items()
 		if paths:
 			model = self.get_model()
 			path_to_uri = lambda p: self.folder.file(model[p][BASENAME_COL]).uri
 			uris = list(map(path_to_uri, paths))
 			data = pack_urilist(uris)
-			selectiondata.set(URI_TARGET_NAMES[0], 8, data)
+			selectiondata.set(selectiondata.get_target(), 8, data)
 
 	def on_drag_data_received(self, iconview, dragcontext, x, y, selectiondata, info, time):
-		assert selectiondata.target in URI_TARGET_NAMES
-		names = unpack_urilist(selectiondata.data)
+		assert selectiondata.get_target().name() in URI_TARGET_NAMES
+		names = unpack_urilist(selectiondata.get_data())
 		files = [LocalFile(uri) for uri in names if uri.startswith('file://')]
-		action = dragcontext.action
+		action = dragcontext.get_selected_action()
 		logger.debug('Drag received %s, %s', action, files)
 
 		if action == Gdk.DragAction.MOVE:

--- a/zim/plugins/pageindex/__init__.py
+++ b/zim/plugins/pageindex/__init__.py
@@ -492,16 +492,16 @@ class PageTreeView(BrowserTreeView):
 			Clipboard.set_pagelink(self.notebook, page)
 
 	def do_drag_data_get(self, dragcontext, selectiondata, info, time):
-		assert selectiondata.target == INTERNAL_PAGELIST_TARGET_NAME
+		assert selectiondata.get_target().name() == INTERNAL_PAGELIST_TARGET_NAME
 		model, iter = self.get_selection().get_selected()
 		path = model.get_indexpath(iter)
 		logger.debug('Drag data requested, we have internal path "%s"', path.name)
 		data = pack_urilist((path.name,))
-		selectiondata.set(INTERNAL_PAGELIST_TARGET_NAME, 8, data)
+		selectiondata.set(selectiondata.get_target(), 8, data)
 
 	def do_drag_data_received(self, dragcontext, x, y, selectiondata, info, time):
-		assert selectiondata.target == INTERNAL_PAGELIST_TARGET_NAME
-		names = unpack_urilist(selectiondata.data)
+		assert selectiondata.get_target().name() == INTERNAL_PAGELIST_TARGET_NAME
+		names = unpack_urilist(selectiondata.get_data())
 		assert len(names) == 1
 		source = Path(names[0])
 

--- a/zim/plugins/pathbar.py
+++ b/zim/plugins/pathbar.py
@@ -604,11 +604,11 @@ class PathBar(ScrolledHBox):
 		return True
 
 	def on_drag_data_get(self, button, context, selectiondata, info, time):
-		assert selectiondata.target == INTERNAL_PAGELIST_TARGET_NAME
+		assert selectiondata.get_target().name() == INTERNAL_PAGELIST_TARGET_NAME
 		path = button.zim_path
 		logger.debug('Drag data requested from PathBar, we have internal path "%s"', path.name)
 		data = pack_urilist((path.name,))
-		selectiondata.set(INTERNAL_PAGELIST_TARGET_NAME, 8, data)
+		selectiondata.set(selectiondata.get_target(), 8, data)
 
 
 class HistoryPathBar(PathBar):

--- a/zim/plugins/tags.py
+++ b/zim/plugins/tags.py
@@ -299,7 +299,7 @@ class TaggedPageTreeStore(TaggedPagesTreeModelMixin, DuplicatePageTreeStore):
 class TagsPageTreeView(PageTreeView):
 
 	def do_drag_data_get(self, dragcontext, selectiondata, info, time):
-		assert selectiondata.target == INTERNAL_PAGELIST_TARGET_NAME
+		assert selectiondata.get_target().name() == INTERNAL_PAGELIST_TARGET_NAME
 		model, iter = self.get_selection().get_selected()
 		path = model.get_indexpath(iter)
 		if isinstance(path, IndexTag):
@@ -308,7 +308,7 @@ class TagsPageTreeView(PageTreeView):
 			link = path.name
 		logger.debug('Drag data requested, we have internal tag/path "%s"', link)
 		data = pack_urilist((link,))
-		selectiondata.set(INTERNAL_PAGELIST_TARGET_NAME, 8, data)
+		selectiondata.set(selectiondata.get_target(), 8, data)
 
 	def set_current_page(self, path, vivificate=False):
 		'''Set the current page in the treeview


### PR DESCRIPTION
# What works

Clipboard:
* These changes make all the tests in #332 work, i.e. copying from outside into Zim works fine now.

DnD:
* These changes make drag&drop from outside (e.g. gedit, nautilus, firefox) to Zim work.

# What doesn't work
Clipboard:
* Copying from Zim to anywhere (Zim or outside) is still broken. This is due to broken Gtk+ Phthon bindings, see #326 for details.

DnD:
* Drag in Zim, drop outside of Zim. 
* Some situations of drag in Zim, drop in Zim (e.g. #385).
In both cases, the Gtk+ Python bindings are to blame, see #390 for details.