### PR TITLE
FileNotFoundError: No such file or folder

### DIFF
--- a/zim/plugins/attachmentbrowser/filebrowser.py
+++ b/zim/plugins/attachmentbrowser/filebrowser.py
@@ -291,7 +291,7 @@ class FileBrowserIconView(gtk.IconView):
 
 	def _on_folder_changed(self, *a):
 		try:
-			changed = self.folder and self.folder.mtime() != self._mtime
+			changed = self.folder and self.folder.exists() and self.folder.mtime() != self._mtime
 		except OSError: # folder went missing?
 			changed = True
 


### PR DESCRIPTION
We might be watching the wrong folder, but sometimes we are alerted to folder changes when our folder does not exist.

```
ERROR: Exception in signal handler for changed on <zim.newfs.helpers.FSObjectMonitor object at 0x7fb2a4cd2a90>
Traceback (most recent call last):
  File "zim/signals.py", line 338, in emit
    r = handler(self, *args)
  File "zim/plugins/attachmentbrowser/filebrowser.py", line 294, in _on_folder_changed
    changed = self.folder and self.folder.mtime() != self._mtime
  File "zim/newfs/local.py", line 70, in mtime
    return self._stat().st_mtime
  File "zim/newfs/local.py", line 54, in _stat
    raise FileNotFoundError(self)
FileNotFoundError: No such file or folder...
```
