### PR TITLE
SVG causes segfaults in Linux too (fix)

### DIFF
--- a/zim/plugins/attachmentbrowser/thumbnailer.py
+++ b/zim/plugins/attachmentbrowser/thumbnailer.py
@@ -88,7 +88,7 @@ def pixbufThumbnailCreator(file, thumbfile, thumbsize):
 	functions to create the thumbnail.
 	'''
 	if not (isinstance(file, LocalFile) and isinstance(thumbfile, LocalFile)) \
-	or (os.name == 'nt' and file.basename.endswith('.svg')):
+	or (file.basename.endswith('.svg')):
 		# .svg causes segfaults on windows, even if svg support enabled 
 		raise ThumbnailCreatorFailure
 


### PR DESCRIPTION
Seems like this now needs to mimic the Windows condition.

